### PR TITLE
Add Knightfall splits

### DIFF
--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -86,7 +86,7 @@ state("BatmanAK", "Steam-Current"){
 	string50 sideMission18Name	: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
-	bool Knightfall 			: 0x03502E44, 0x34, 0x44, 0x1A8, 0x470, 0xA0, 0x40, 0xDC8; // 1 when entering most of the time a un-skippable cutscene sometimes for skippable. Then 0 for any other state like skippable cutscene or not in a cutscene.
+	bool CinematicCutscene 		: 0x03502E44, 0x34, 0x44, 0x1A8, 0x470, 0xA0, 0x40, 0xDC8; // 1 when entering most of the time a un-skippable cutscene sometimes for skippable. Then 0 for any other state like skippable cutscene or not in a cutscene.
 	int Cutscene				: 0x03728F5C, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
 	/* comment on Cutscene Continued
 	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
@@ -138,7 +138,7 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
-	bool Knightfall 			: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
+	bool CinematicCutscene 		: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
 	int Cutscene				: 0x03797024, 0x108;
 }
 
@@ -147,18 +147,12 @@ startup{
 	settings.SetToolTip("highDetail", "Use every possible split point. Not recommended");
 	settings.Add("sideMissions", false, "Side Missions");
 	settings.Add("splitOnJoker", false, "Split at the end of the Main Story");
-	settings.Add("Knightfall first ending", false, "Knightfall First Ending");
-	settings.SetToolTip("Knightfall first ending", "Use this if you are speed-running Knightfall First Ending");
-	settings.Add("Knightfall full ending", false, "Knightfall Full Ending");
-	settings.SetToolTip("Knightfall full ending", "Use this if you are speed-running Knightfall Full Ending");
 
 	vars.splitPoints = new List<int>{
 		5, 10, 16, 20, 24, 26, 28, 31, 37, 39, 40, 42, 45, 46, 50, 55, 58, 60, 63,
 		64, 66, 67, 68, 69, 70, 73, 75, 77, 78, 79, 80, 82, 85, 87, 89, 90, 95, 96
 	};
 	vars.highestPercent = 0;
-	vars.TotalSideMissionsDone = 0; // need this to ideally avoid double splits but even without it may not double split but just keeping it just in case
-	vars.CompletedSideMissions = new List<bool>(new bool[18]); // Need this to avoid side missions that are already done being counted twice as done and so if the game crashes the variable doesn't get messed up
 	vars.individualHighest = new List<byte>(new byte[18]);
 
 	// This list holds all side missions as tuples where:
@@ -213,9 +207,7 @@ update{
 	current.timerPhase = timer.CurrentPhase;
 	if(current.timerPhase.ToString() == "Running" && old.timerPhase.ToString() == "NotRunning"){
 		// When the timer starts, reset these things
-		vars.TotalSideMissionsDone = 0;
 		vars.highestPercent = current.storyPercentage;
-		vars.CompletedSideMissions = new List<bool>(new bool[18]);
 		
 		vars.individualHighest = new List<byte>();
 		if(vars.sideMissionNames.Contains(current.sideMission1Name)){
@@ -309,17 +301,6 @@ update{
 			vars.individualHighest.Add(0);
 		}
 	}
-	// count the variable up also the bools so it doesn't double count if the value goes back down due to a crash or going to main menu.
-	if (settings["Knightfall full ending"] || settings["Knightfall first ending"]){
-		for (int i = 0; i < 18; i++){
-			var MissionName = vars.sideMissions[i].Item2(current);
-    		var MissionProgress = vars.sideMissions[i].Item1(current);
-			if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
-				vars.CompletedSideMissions[i] = true;
-				vars.TotalSideMissionsDone++;
-			}
-		}
-	}
 }
 
 split{
@@ -391,11 +372,11 @@ split{
 		}
 	}
 	// full ending split ng and ng+
-	if (settings["Knightfall full ending"] && current.Knightfall && vars.TotalSideMissionsDone >= 14 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
 	// full ending split ng only because thats the only cat that has it
-	if (settings["Knightfall first ending"] && current.Knightfall && vars.TotalSideMissionsDone >= 7 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
+	if (current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
 		return true;			
 	}
 	// 240% split

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -153,6 +153,8 @@ startup{
 		64, 66, 67, 68, 69, 70, 73, 75, 77, 78, 79, 80, 82, 85, 87, 89, 90, 95, 96
 	};
 	vars.highestPercent = 0;
+	vars.TotalSideMissionsDone = 0;
+	vars.CompletedSideMissions = new List<bool>(new bool[18]); // makes sure we dont count a side mission twice as completed
 	vars.individualHighest = new List<byte>(new byte[18]);
 
 	// This list holds all side missions as tuples where:
@@ -207,6 +209,8 @@ update{
 	current.timerPhase = timer.CurrentPhase;
 	if(current.timerPhase.ToString() == "Running" && old.timerPhase.ToString() == "NotRunning"){
 		// When the timer starts, reset these things
+		vars.TotalSideMissionsDone = 0;
+		vars.CompletedSideMissions = new List<bool>(new bool[18]);
 		vars.highestPercent = current.storyPercentage;
 		
 		vars.individualHighest = new List<byte>();
@@ -301,6 +305,15 @@ update{
 			vars.individualHighest.Add(0);
 		}
 	}
+	
+	for (int i = 0; i < 18; i++){
+		var MissionName = vars.sideMissions[i].Item2(current);
+		var MissionProgress = vars.sideMissions[i].Item1(current);
+		if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
+				vars.CompletedSideMissions[i] = true;
+				vars.TotalSideMissionsDone++;
+			}
+		}
 }
 
 split{
@@ -371,12 +384,12 @@ split{
 			return true;
 		}
 	}
-	// full ending split ng and ng+
-	if (current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	// first ending split
+	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
-	// full ending split ng only because thats the only cat that has it
-	if (current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
+	// full ending split
+	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
 		return true;			
 	}
 	// 240% split

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -86,6 +86,15 @@ state("BatmanAK", "Steam-Current"){
 	string50 sideMission18Name	: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
+	bool Knightfall 			: 0x03502E44, 0x34, 0x44, 0x1A8, 0x470, 0xA0, 0x40, 0xDC8; // 1 when entering most of the time a un-skippable cutscene sometimes for skippable. Then 0 for any other state like skippable cutscene or not in a cutscene.
+	int Cutscene				: 0x03728F5C, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
+	/* comment on Cutscene Continued
+	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
+	* 758 seems to be in a cutscene or for like radio comms(thats skippable) like for when you are talking to Alfred after you complete everything and knightfall is ready.
+	* 1014 seems to be also in a cutscene but for like when its un-skippable.
+	* Then there's other values like 766 and 1022 which only happen during cutscenes for like a second or so.
+	* 766 may be related to Jason being in the cutscene specially at the end of the game with the truck crashing and with him saving you from scarecrow/
+	*/
 }
 
 state("BatmanAK", "Epic"){
@@ -129,6 +138,9 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
+	// extra pointers not part of the same base address as the rest of the pointers 
+	bool Knightfall 			: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
+	int Cutscene				: 0x03797024, 0x108;
 }
 
 startup{
@@ -136,12 +148,18 @@ startup{
 	settings.SetToolTip("highDetail", "Use every possible split point. Not recommended");
 	settings.Add("sideMissions", false, "Side Missions");
 	settings.Add("splitOnJoker", false, "Split at the end of the Main Story");
+	settings.Add("Knightfall first ending", false, "Knightfall First Ending");
+	settings.SetToolTip("Knightfall first ending", "Use this if you are speed-running Knightfall First Ending");
+	settings.Add("Knightfall full ending", false, "Knightfall Full Ending");
+	settings.SetToolTip("Knightfall full ending", "Use this if you are speed-running Knightfall Full Ending");
 
 	vars.splitPoints = new List<int>{
 		5, 10, 16, 20, 24, 26, 28, 31, 37, 39, 40, 42, 45, 46, 50, 55, 58, 60, 63,
 		64, 66, 67, 68, 69, 70, 73, 75, 77, 78, 79, 80, 82, 85, 87, 89, 90, 95, 96
 	};
 	vars.highestPercent = 0;
+	vars.TotalSideMissionsDone = 0; // need this to ideally avoid double splits but even without it may not double split but just keeping it just in case
+	vars.CompletedSideMissions = new List<bool>(new bool[18]); // Need this to avoid side missions that are already done being counted twice as done and so if the game crashes the variable doesn't get messed up
 	vars.individualHighest = new List<byte>(new byte[18]);
 	
 	vars.sideMissionNames = new List<string>{
@@ -170,7 +188,9 @@ update{
 	current.timerPhase = timer.CurrentPhase;
 	if(current.timerPhase.ToString() == "Running" && old.timerPhase.ToString() == "NotRunning"){
 		// When the timer starts, reset these things
+		vars.TotalSideMissionsDone = 0;
 		vars.highestPercent = current.storyPercentage;
+		vars.CompletedSideMissions = new List<bool>(new bool[18]);
 		
 		vars.individualHighest = new List<byte>();
 		if(vars.sideMissionNames.Contains(current.sideMission1Name)){
@@ -264,6 +284,81 @@ update{
 			vars.individualHighest.Add(0);
 		}
 	}
+	// count the variable up also the bools so it doesn't double count if the value goes back down due to a crash or going to main menu.
+	if (settings["Knightfall full ending"] || settings["Knightfall first ending"]){
+		if(current.sideMission1 == 100 && !vars.CompletedSideMissions[0]){
+			vars.CompletedSideMissions[0] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission2 == 100 && !vars.CompletedSideMissions[1]){
+			vars.CompletedSideMissions[1] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission3 == 100 && !vars.CompletedSideMissions[2]){
+			vars.CompletedSideMissions[2] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission4 == 100 && !vars.CompletedSideMissions[3]){
+			vars.CompletedSideMissions[3] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission5 == 100 && !vars.CompletedSideMissions[4]){
+			vars.CompletedSideMissions[4] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission6 == 100 && !vars.CompletedSideMissions[5]){
+			vars.CompletedSideMissions[5] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission7 == 100 && !vars.CompletedSideMissions[6]){
+			vars.CompletedSideMissions[6] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission8 == 100 && !vars.CompletedSideMissions[7]){
+			vars.CompletedSideMissions[7] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission9 == 100 && !vars.CompletedSideMissions[8]){
+			vars.CompletedSideMissions[8] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission10 == 100 && !vars.CompletedSideMissions[9]){
+			vars.CompletedSideMissions[9] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission11 == 100 && !vars.CompletedSideMissions[10]){
+			vars.CompletedSideMissions[10] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission12 == 100 && !vars.CompletedSideMissions[11]){
+			vars.CompletedSideMissions[11] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission13 == 100 && !vars.CompletedSideMissions[12]){
+			vars.CompletedSideMissions[12] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission14 == 100 && !vars.CompletedSideMissions[13]){
+			vars.CompletedSideMissions[13] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission15 == 100 && !vars.CompletedSideMissions[14]){
+			vars.CompletedSideMissions[14] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission16 == 100 && !vars.CompletedSideMissions[15]){
+			vars.CompletedSideMissions[15] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission17 == 100 && !vars.CompletedSideMissions[16]){
+			vars.CompletedSideMissions[16] = true;
+			vars.TotalSideMissionsDone++;
+		}
+		if(current.sideMission18 == 100 && !vars.CompletedSideMissions[17]){
+			vars.CompletedSideMissions[17] = true;
+			vars.TotalSideMissionsDone++;
+		}
+	}
 }
 
 split{
@@ -333,6 +428,14 @@ split{
 		if(current.currentLevel == "JokerBoss_B2" && old.jokerPunches > current.jokerPunches){
 			return true;
 		}
+	}
+	// full ending split ng and ng+
+	if (settings["Knightfall full ending"] && current.Knightfall && vars.TotalSideMissionsDone >= 14 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+		return true;		
+	}
+	// full ending split ng only because thats the only cat that has it
+	if (settings["Knightfall first ending"] && current.Knightfall && vars.TotalSideMissionsDone >= 7 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
+		return true;			
 	}
 	// 240% split
 	if(current.OverallPercentage == 240 && old.OverallPercentage != 240){

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -138,7 +138,6 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
-	// extra pointers not part of the same base address as the rest of the pointers 
 	bool Knightfall 			: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
 	int Cutscene				: 0x03797024, 0x108;
 }
@@ -161,6 +160,32 @@ startup{
 	vars.TotalSideMissionsDone = 0; // need this to ideally avoid double splits but even without it may not double split but just keeping it just in case
 	vars.CompletedSideMissions = new List<bool>(new bool[18]); // Need this to avoid side missions that are already done being counted twice as done and so if the game crashes the variable doesn't get messed up
 	vars.individualHighest = new List<byte>(new byte[18]);
+
+	// This list holds all side missions as tuples where:
+	// - Item1 is a function that returns the mission progress (byte) for a given game state
+	// - Item2 is a function that returns the mission name (string) for a given game state
+	// It allows us to loop through all side missions without writing repetitive if/else chains,
+	// keeping code compact while still tracking progress and names dynamically.
+	vars.sideMissions = new List<Tuple<Func<dynamic, byte>, Func<dynamic, string>>> {
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission1, s => s.sideMission1Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission2, s => s.sideMission2Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission3, s => s.sideMission3Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission4, s => s.sideMission4Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission5, s => s.sideMission5Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission6, s => s.sideMission6Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission7, s => s.sideMission7Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission8, s => s.sideMission8Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission9, s => s.sideMission9Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission10, s => s.sideMission10Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission11, s => s.sideMission11Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission12, s => s.sideMission12Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission13, s => s.sideMission13Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission14, s => s.sideMission14Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission15, s => s.sideMission15Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission16, s => s.sideMission16Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission17, s => s.sideMission17Name),
+		Tuple.Create<Func<dynamic, byte>, Func<dynamic, string>>(s => s.sideMission18, s => s.sideMission18Name)
+	};
 	
 	vars.sideMissionNames = new List<string>{
 		"Firecrews", "Pyg", "Drones", "ManBat", "Azrael",
@@ -286,77 +311,13 @@ update{
 	}
 	// count the variable up also the bools so it doesn't double count if the value goes back down due to a crash or going to main menu.
 	if (settings["Knightfall full ending"] || settings["Knightfall first ending"]){
-		if(current.sideMission1 == 100 && !vars.CompletedSideMissions[0]){
-			vars.CompletedSideMissions[0] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission2 == 100 && !vars.CompletedSideMissions[1]){
-			vars.CompletedSideMissions[1] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission3 == 100 && !vars.CompletedSideMissions[2]){
-			vars.CompletedSideMissions[2] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission4 == 100 && !vars.CompletedSideMissions[3]){
-			vars.CompletedSideMissions[3] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission5 == 100 && !vars.CompletedSideMissions[4]){
-			vars.CompletedSideMissions[4] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission6 == 100 && !vars.CompletedSideMissions[5]){
-			vars.CompletedSideMissions[5] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission7 == 100 && !vars.CompletedSideMissions[6]){
-			vars.CompletedSideMissions[6] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission8 == 100 && !vars.CompletedSideMissions[7]){
-			vars.CompletedSideMissions[7] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission9 == 100 && !vars.CompletedSideMissions[8]){
-			vars.CompletedSideMissions[8] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission10 == 100 && !vars.CompletedSideMissions[9]){
-			vars.CompletedSideMissions[9] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission11 == 100 && !vars.CompletedSideMissions[10]){
-			vars.CompletedSideMissions[10] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission12 == 100 && !vars.CompletedSideMissions[11]){
-			vars.CompletedSideMissions[11] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission13 == 100 && !vars.CompletedSideMissions[12]){
-			vars.CompletedSideMissions[12] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission14 == 100 && !vars.CompletedSideMissions[13]){
-			vars.CompletedSideMissions[13] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission15 == 100 && !vars.CompletedSideMissions[14]){
-			vars.CompletedSideMissions[14] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission16 == 100 && !vars.CompletedSideMissions[15]){
-			vars.CompletedSideMissions[15] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission17 == 100 && !vars.CompletedSideMissions[16]){
-			vars.CompletedSideMissions[16] = true;
-			vars.TotalSideMissionsDone++;
-		}
-		if(current.sideMission18 == 100 && !vars.CompletedSideMissions[17]){
-			vars.CompletedSideMissions[17] = true;
-			vars.TotalSideMissionsDone++;
+		for (int i = 0; i < 18; i++){
+			var MissionName = vars.sideMissions[i].Item2(current);
+    		var MissionProgress = vars.sideMissions[i].Item1(current);
+			if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
+				vars.CompletedSideMissions[i] = true;
+				vars.TotalSideMissionsDone++;
+			}
 		}
 	}
 }

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -87,7 +87,7 @@ state("BatmanAK", "Steam-Current"){
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
 	bool CinematicCutscene 		: 0x03502E44, 0x34, 0x44, 0x1A8, 0x470, 0xA0, 0x40, 0xDC8; // 1 when entering most of the time a un-skippable cutscene sometimes for skippable. Then 0 for any other state like skippable cutscene or not in a cutscene.
-	int Cutscene				: 0x03728F5C, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
+	int Cutscene				: 0x0311F508, 0x84C, 0x0, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
 	/* comment on Cutscene Continued
 	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
 	* 758 seems to be in a cutscene or for like radio comms(thats skippable) like for when you are talking to Alfred after you complete everything and knightfall is ready.
@@ -139,7 +139,7 @@ state("BatmanAK", "Epic"){
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
 	bool CinematicCutscene 		: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
-	int Cutscene				: 0x03797024, 0x108;
+	int Cutscene				: 0x0318D5B8, 0x84C, 0x0, 0x108;
 }
 
 startup{

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -86,7 +86,7 @@ state("BatmanAK", "Steam-Current"){
 	string50 sideMission18Name	: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
-	int CinematicCutscene		: 0x3AF65EC; // 0 for when not in a cutscene and 1 for when in a cutscene, but for some reason sometimes 2 and sometimes on knightfall cutscene its on 3 idk why.
+	bool Paused					: 0x30FFF64; // 0 for not paused and 1 for when in pause menu or most wanted menu map and other stuff is still 0
 	int Cutscene				: 0x0311F508, 0x84C, 0x0, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
 	/* comment on Cutscene Continued
 	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
@@ -138,7 +138,7 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
-	int CinematicCutscene		: 0x3B646AC;
+	bool Paused					: 0x316DFA4;
 	int Cutscene				: 0x0318D5B8, 0x84C, 0x0, 0x108;
 }
 
@@ -384,13 +384,9 @@ split{
 			return true;
 		}
 	}
-	// first ending split
-	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene > 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	// KnightFall Split
+	if (vars.TotalSideMissionsDone >= 7 && !current.Paused && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
-	}
-	// full ending split
-	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene > 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
-		return true;			
 	}
 	// 240% split
 	if(current.OverallPercentage == 240 && old.OverallPercentage != 240){

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -86,7 +86,6 @@ state("BatmanAK", "Steam-Current"){
 	string50 sideMission18Name	: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
-	bool CinematicCutscene 		: 0x03502E44, 0x34, 0x44, 0x1A8, 0x470, 0xA0, 0x40, 0xDC8; // 1 when entering most of the time a un-skippable cutscene sometimes for skippable. Then 0 for any other state like skippable cutscene or not in a cutscene.
 	int Cutscene				: 0x0311F508, 0x84C, 0x0, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
 	/* comment on Cutscene Continued
 	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
@@ -138,7 +137,6 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
-	bool CinematicCutscene 		: 0x035124EC, 0x34, 0xD44, 0xB68, 0x470, 0xA0, 0x40, 0xDC8;
 	int Cutscene				: 0x0318D5B8, 0x84C, 0x0, 0x108;
 }
 
@@ -385,11 +383,11 @@ split{
 		}
 	}
 	// first ending split
-	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone == 7 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
 	// full ending split
-	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
+	if (vars.TotalSideMissionsDone == 14 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
 		return true;			
 	}
 	// 240% split

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -306,14 +306,15 @@ update{
 		}
 	}
 	
-	for (int i = 0; i <= 13; i++){
+	for (int i = 0; i <= 13; i++) {
 		var MissionName = vars.sideMissions[i].Item2(current);
 		var MissionProgress = vars.sideMissions[i].Item1(current);
-		if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
+		var MissionProgressOld = vars.sideMissions[i].Item1(old);
+		if (MissionProgress == 100 && current.storyPercentage >= 59 && MissionProgressOld < 100 && MissionProgressOld >= 0 !vars.CompletedSideMissions[i]){
 				vars.CompletedSideMissions[i] = true;
 				vars.TotalSideMissionsDone++;
-			}
 		}
+	}
 }
 
 split{

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -306,7 +306,7 @@ update{
 		}
 	}
 	
-	for (int i = 0; i <= 17; i++){
+	for (int i = 0; i <= 13; i++){
 		var MissionName = vars.sideMissions[i].Item2(current);
 		var MissionProgress = vars.sideMissions[i].Item1(current);
 		if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
@@ -385,11 +385,11 @@ split{
 		}
 	}
 	// first ending split
-	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene != old.CinematicCutscene && !current.Paused && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene > 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
 	// full ending split
-	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene != old.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene > 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;			
 	}
 	// 240% split

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -86,6 +86,7 @@ state("BatmanAK", "Steam-Current"){
 	string50 sideMission18Name	: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0311F508, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0311F508, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C; // save file percentage (0-240)
+	int CinematicCutscene		: 0x3AF65EC; // 0 for when not in a cutscene and 1 for when in a cutscene, but for some reason sometimes 2 and sometimes on knightfall cutscene its on 3 idk why.
 	int Cutscene				: 0x0311F508, 0x84C, 0x0, 0x108; // I dont exactly know what its tracking but it seems to be consistent that 754 and 1010 are something related to not in a cutscene.
 	/* comment on Cutscene Continued
 	* 754 seems to be consistent this is no cutscene full gameplay, 1010 is like theirs some gameplay but its transitioning into or out of a cutscene.
@@ -137,6 +138,7 @@ state("BatmanAK", "Epic"){
 	string50 sideMission18Name	: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x614, 0xA14, 0xA70, 0x0;
 	int jokerPunches			: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0xA9C, 0x1AA8;
 	int OverallPercentage		: 0x0318D5B8, 0x84C, 0x0, 0x5C, 0x9C, 0x5AC, 0x4D8, 0x36C, 0x13C;
+	int CinematicCutscene		: 0x3B646AC;
 	int Cutscene				: 0x0318D5B8, 0x84C, 0x0, 0x108;
 }
 
@@ -304,7 +306,7 @@ update{
 		}
 	}
 	
-	for (int i = 0; i < 18; i++){
+	for (int i = 0; i <= 17; i++){
 		var MissionName = vars.sideMissions[i].Item2(current);
 		var MissionProgress = vars.sideMissions[i].Item1(current);
 		if (MissionProgress == 100 && !vars.CompletedSideMissions[i]){
@@ -383,11 +385,11 @@ split{
 		}
 	}
 	// first ending split
-	if (vars.TotalSideMissionsDone == 7 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene >= 1 && old.CinematicCutscene == 0 && !current.Paused && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
 	// full ending split
-	if (vars.TotalSideMissionsDone == 14 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){ 
+	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene >= 1 && old.CinematicCutscene == 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;			
 	}
 	// 240% split

--- a/ArkhamKnight.asl
+++ b/ArkhamKnight.asl
@@ -385,11 +385,11 @@ split{
 		}
 	}
 	// first ending split
-	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene >= 1 && old.CinematicCutscene == 0 && !current.Paused && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone == 7 && current.CinematicCutscene != old.CinematicCutscene && !current.Paused && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;		
 	}
 	// full ending split
-	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene >= 1 && old.CinematicCutscene == 0 && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
+	if (vars.TotalSideMissionsDone >= 14 && current.CinematicCutscene != old.CinematicCutscene && current.storyPercentage == 100 && current.currentLevel == "CityZ_17" && current.Cutscene == 758 && old.Cutscene == 754){
 		return true;			
 	}
 	// 240% split


### PR DESCRIPTION
This pull request adds splits for knightfall's first ending and full ending. Basically it splits on activating the bat signal for knightfall. 
I added 2 variables one is a int that just counts how many side missions you have done and the other is a list of bools for each side mission. To avoid the counter variable counting a side mission twice. 
Also added 2 new pointers for both steam current and epic so knight fall splits can work.