### PR TITLE
Added auto split for current patch and fixed load remover

### DIFF
--- a/GothamKnights.asl
+++ b/GothamKnights.asl
@@ -83,7 +83,6 @@ state("GothamKnights", "Epic 2023.04.27"){
 }
 
 init{
-	vars.version = "Unknown Version";
 	switch(modules.First().ModuleMemorySize){
 		case 0x1C70F000:
 			version = "Steam 2022.10.21";
@@ -146,13 +145,12 @@ init{
 			print("Unrecognized Module Size: " + modules.First().ModuleMemorySize.ToString());
 			break;
 	}
-	vars.version = version;
 }
 
 split
 {
 	// splits when reaching the next night
-	if (current.CurrentNight > old.CurrentNight && vars.version == "Steam 2026.2.26") {
+	if (current.CurrentNight > old.CurrentNight) {
 		return true;
 	}
 }

--- a/GothamKnights.asl
+++ b/GothamKnights.asl
@@ -1,9 +1,6 @@
-/***************************************************************
- * Gotham Knights ASL Script
- * Created by ShikenNuggets
- * Updated By TpRedNinja
-***************************************************************/
-// Removes loads and auto splits when the night ends
+//Gotham Knights Autosplitter and Load Remover v1.1
+//Created by ShikenNuggets and TpRedNinja
+//Pauses on load screens and splits at the end of each night
 
 state("GothamKnights-Win64-Shipping", "Steam 2022.10.21"){
 	byte loading	: 0x072A1F88, 0x4B0, 0x0, 0x230, 0xC8, 0x8, 0x5F0, 0x490;
@@ -49,8 +46,8 @@ state("GothamKnights", "Steam 2023.09.26"){
 	byte loading	: 0x072CC650, 0x140, 0x5F8, 0x490;
 }
 
-state("GothamKnights", "Steam 2026.2.26"){
-	int CurrentNight	: 0x73F3EC8, 0x7C8, 0x80, 0x38, 0x0, 0x30, 0x278, 0x408; // the current night you are on.
+state("GothamKnights", "Steam 2026.02.26"){
+	int CurrentNight	: 0x73F3EC8, 0x7C8, 0x80, 0x38, 0x0, 0x30, 0x278, 0x408;
 	byte loading 	: 0x071B6A30, 0x0, 0x358, 0xE8, 0x8, 0x3E8;
 }
 
@@ -118,7 +115,7 @@ init{
 			version = "Steam 2023.09.26";
 			break;
 		case 129413120:
-			version = "Steam 2026.2.26";
+			version = "Steam 2026.02.26";
 			break;
 		case 0x1CE58000:
 			version = "Epic 2022.11.07";
@@ -147,8 +144,7 @@ init{
 	}
 }
 
-split
-{
+split{
 	// splits when reaching the next night
 	if (current.CurrentNight > old.CurrentNight) {
 		return true;
@@ -156,6 +152,5 @@ split
 }
 
 isLoading{
-
 	return current.loading == 1;
 }

--- a/GothamKnights.asl
+++ b/GothamKnights.asl
@@ -1,6 +1,9 @@
-//Gotham Knights Load Remover v1.0
-//Created by ShikenNuggets
-//Pauses on load screens
+/***************************************************************
+ * Gotham Knights ASL Script
+ * Created by ShikenNuggets
+ * Updated By TpRedNinja
+***************************************************************/
+// Removes loads and auto splits when the night ends
 
 state("GothamKnights-Win64-Shipping", "Steam 2022.10.21"){
 	byte loading	: 0x072A1F88, 0x4B0, 0x0, 0x230, 0xC8, 0x8, 0x5F0, 0x490;
@@ -46,6 +49,11 @@ state("GothamKnights", "Steam 2023.09.26"){
 	byte loading	: 0x072CC650, 0x140, 0x5F8, 0x490;
 }
 
+state("GothamKnights", "Steam 2026.2.26"){
+	int CurrentNight	: 0x73F3EC8, 0x7C8, 0x80, 0x38, 0x0, 0x30, 0x278, 0x408; // the current night you are on.
+	byte loading 	: 0x071B6A30, 0x0, 0x358, 0xE8, 0x8, 0x3E8;
+}
+
 state("GothamKnights", "Epic 2022.11.07"){
 	byte loading	: 0x07092B70, 0x0, 0x38, 0x8, 0x150, 0x490;
 }
@@ -75,6 +83,7 @@ state("GothamKnights", "Epic 2023.04.27"){
 }
 
 init{
+	vars.version = "Unknown Version";
 	switch(modules.First().ModuleMemorySize){
 		case 0x1C70F000:
 			version = "Steam 2022.10.21";
@@ -109,6 +118,9 @@ init{
 		case 478765056:
 			version = "Steam 2023.09.26";
 			break;
+		case 129413120:
+			version = "Steam 2026.2.26";
+			break;
 		case 0x1CE58000:
 			version = "Epic 2022.11.07";
 			break;
@@ -134,8 +146,18 @@ init{
 			print("Unrecognized Module Size: " + modules.First().ModuleMemorySize.ToString());
 			break;
 	}
+	vars.version = version;
+}
+
+split
+{
+	// splits when reaching the next night
+	if (current.CurrentNight > old.CurrentNight && vars.version == "Steam 2026.2.26") {
+		return true;
+	}
 }
 
 isLoading{
+
 	return current.loading == 1;
 }


### PR DESCRIPTION
Found a pointer for the current night you are on so it splits when the night increase and it increases when the night ends. So you start on 0 then when you end it it goes to 1 and then so on and so forth. Weirdly though if u crash or close the game during a night or in the belfrey it goes to 0 and then fixes itself when you complete the night so thats nice. So the if statement is just simple. loading pointer i have 0 clue if it behaves the same i asked ryan if it stays paused on loading screen even if the continue prompt is their and he said yes so i went base off that if thats not the case i can change