### PR TITLE
TwoFace Final ArkhamCity.asl

### DIFF
--- a/ArkhamCity.asl
+++ b/ArkhamCity.asl
@@ -50,8 +50,6 @@ startup{
 	settings.Add("splitOnBatsuit", false, "Split on Batsuit", "legacyMode");
 	settings.Add("splitOnClayface", false, "Split on Clayface", "legacyMode");
 	
-	settings.Add("twoFaceAutoSplit", true, "Two-Face: auto-split on health bar disappearance (Any% w/Cat)");
-	settings.SetToolTip("twoFaceAutoSplit", "Splits the instant Two-Face's health bar fades off screen.");
 	
 	vars.state = 0;
 	vars.cutscenesThisChapter = 0;
@@ -81,7 +79,7 @@ update{
 		vars.tfSplitDone = false;
 	}
 	
-	if(current.tfBoss != 0) vars.tfBossWasActive = true;
+	if(current.chapter == 9 && current.character.Contains("Playable_Catwoman") && current.tfBoss != 0) vars.tfBossWasActive = true;
 	
 	if(settings["startAfterSkin"] && vars.state == 0 && current.skin == 1){
 		vars.state = 4;
@@ -218,8 +216,6 @@ split{
 			return true; //Batsuit
 		}else if(current.chapter == 7 && old.character.Contains("Playable_Catwoman") && current.character.Contains("Playable_Batman")){
 			return true; //After Cat 3
-		}else if(current.chapter == 9 && current.lastDoorRoom.Contains("Museum_") && old.character.Contains("Playable_Catwoman") && current.character.Contains("Playable_Batman")){
-			return true; //After Cat 4
 		}else if(current.chapter == 9 && !current.lastDoorRoom.Contains("Under_S2") && old.character.Contains("Playable_Batman") && current.character.Contains("Playable_Catwoman")){
 			return true; //Before Catwoman Cleanup (100%)
 		}else if(old.character.Contains("Playable_Batman") && current.character.Contains("Playable_Robin")){
@@ -235,7 +231,7 @@ split{
 	}
 	
 	//---Two-Face (Any% w/Cat)---
-	if(settings["twoFaceAutoSplit"] && current.chapter == 9 && current.character.Contains("Playable_Catwoman") && !vars.tfSplitDone && vars.tfBossWasActive && current.tfBoss == 0 && current.gameState == 0x02 && game != null && !game.HasExited){
+	if(current.chapter == 9 && current.lastDoorRoom.Contains("Museum_") && current.character.Contains("Playable_Catwoman") && !vars.tfSplitDone && vars.tfBossWasActive && current.tfBoss == 0 && current.gameState == 0x02){
 		vars.tfSplitDone = true;
 		return true; //Two-Face's health bar faded off screen
 	}

--- a/ArkhamCity.asl
+++ b/ArkhamCity.asl
@@ -235,13 +235,7 @@ split{
 	}
 	
 	//---Two-Face (Any% w/Cat)---
-	if(settings["twoFaceAutoSplit"]
-		&& current.chapter == 9
-		&& current.character.Contains("Playable_Catwoman")
-		&& !vars.tfSplitDone
-		&& vars.tfBossWasActive && current.tfBoss == 0
-		&& current.gameState == 0x02
-		&& game != null && !game.HasExited){
+	if(settings["twoFaceAutoSplit"] && current.chapter == 9 && current.character.Contains("Playable_Catwoman") && !vars.tfSplitDone && vars.tfBossWasActive && current.tfBoss == 0 && current.gameState == 0x02 && game != null && !game.HasExited){
 		vars.tfSplitDone = true;
 		return true; //Two-Face's health bar faded off screen
 	}

--- a/ArkhamCity.asl
+++ b/ArkhamCity.asl
@@ -1,6 +1,7 @@
 //Batman: Arkham City Autosplitter v4.0
 //Created by ShikenNuggets and JohnStephenEvil
 //Splits in a bunch of places for a bunch of reasons
+//V4.1 Splits on Two-Face healthbar disappearance
 
 state("BatmanAC", "Steam"){
 	int isReloading			: 0x011711E8;
@@ -15,6 +16,8 @@ state("BatmanAC", "Steam"){
 	string50 currentLevel	: 0x01263118, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0x98, 0x0;
 	byte chapter			: 0x01263118, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0xE6;
 	byte subChapter			: 0x01263118, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0xE7;
+	int tfBoss				: 0x01263118, 0xC, 0x278, 0x30, 0x18, 0x3C;
+	byte gameState			: 0x012A5474, 0x18, 0x0, 0x60, 0x1EC;
 }
 
 state("BatmanAC", "Epic"){
@@ -30,6 +33,8 @@ state("BatmanAC", "Epic"){
 	string50 currentLevel	: 0x0124DD38, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0x98, 0x0;
 	byte chapter			: 0x0124DD38, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0xE6;
 	byte subChapter			: 0x0124DD38, 0x20, 0x8C, 0xC0, 0x484, 0x348, 0xE7;
+	int tfBoss				: 0x0124DD38, 0xC, 0x278, 0x30, 0x18, 0x3C;
+	byte gameState			: 0x01290094, 0x18, 0x0, 0x60, 0x1EC;
 }
 
 startup{
@@ -45,8 +50,13 @@ startup{
 	settings.Add("splitOnBatsuit", false, "Split on Batsuit", "legacyMode");
 	settings.Add("splitOnClayface", false, "Split on Clayface", "legacyMode");
 	
+	settings.Add("twoFaceAutoSplit", true, "Two-Face: auto-split on health bar disappearance (Any% w/Cat)");
+	settings.SetToolTip("twoFaceAutoSplit", "Splits the instant Two-Face's health bar fades off screen.");
+	
 	vars.state = 0;
 	vars.cutscenesThisChapter = 0;
+	vars.tfBossWasActive = false;
+	vars.tfSplitDone = false;
 }
 
 init{
@@ -67,7 +77,11 @@ update{
 	current.timerPhase = timer.CurrentPhase;
 	if(old.timerPhase.ToString() == "NotRunning" && current.timerPhase.ToString() == "Running"){
 		vars.cutscenesThisChapter = 0;
+		vars.tfBossWasActive = false;
+		vars.tfSplitDone = false;
 	}
+	
+	if(current.tfBoss != 0) vars.tfBossWasActive = true;
 	
 	if(settings["startAfterSkin"] && vars.state == 0 && current.skin == 1){
 		vars.state = 4;
@@ -218,5 +232,17 @@ split{
 	//---Other---
 	if(!string.IsNullOrWhiteSpace(current.lastDoorRoom) && current.lastDoorRoom.Contains("Under_S2") && old.clayface == current.clayface - 32){
 		return true; //Clayface interaction
+	}
+	
+	//---Two-Face (Any% w/Cat)---
+	if(settings["twoFaceAutoSplit"]
+		&& current.chapter == 9
+		&& current.character.Contains("Playable_Catwoman")
+		&& !vars.tfSplitDone
+		&& vars.tfBossWasActive && current.tfBoss == 0
+		&& current.gameState == 0x02
+		&& game != null && !game.HasExited){
+		vars.tfSplitDone = true;
+		return true; //Two-Face's health bar faded off screen
 	}
 }


### PR DESCRIPTION
Line-by-line explanation
------------------------
Steam/GOG
  int tfBoss      : 0x01263118, 0xC, 0x278, 0x30, 0x18, 0x3C;
    Two-Face's pawn base
  byte gameState  : 0x012A5474, 0x18, 0x0, 0x60, 0x1EC;
    game state when paused 2, when resumed 3, (sometimes 0 doesn't matter)

Epic
  int tfBoss      : 0x0124DD38, 0xC, 0x278, 0x30, 0x18, 0x3C;
"""
  byte gameState  : 0x01290094, 0x18, 0x0, 0x60, 0x1EC;
"""

settings["twoFaceAutoSplit"]
  The LiveSplit setting/checkbox is enabled.

current.chapter == 9
  We are in chapter 9, the Catwoman endgame portion.

current.character.Contains("Playable_Catwoman")
  The player is Catwoman, not Batman.

!vars.tfSplitDone
  The Two-Face autosplit has not already fired this run.

vars.tfBossWasActive
  The script previously saw Two-Face's boss pawn loaded/active.

current.tfBoss == 0
  The boss pawn slot is now cleared, meaning Two-Face has been defeated.

current.gameState == 0x02
  The UI/game state byte is in the stopped/hidden state. During the
  Two-Face fight, this matches the health bar disappearing.

game != null && !game.HasExited
  The game process still exists and has not crashed/exited.

vars.tfSplitDone = true
  Prevents the Two-Face condition from firing repeatedly after it becomes
  true.

return true
  Tells LiveSplit to split.

FOR MORE INFORMATION VISIT THIS GOOGLE DOCS LINK- https://docs.google.com/document/d/1u0hrQ3YhnJDh_Dy2ICirni6CBi5iOjHa4Envm98nNgc/edit?usp=sharing